### PR TITLE
Update for jupyterlab-deck 0.2.0a0

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,15 +1,2 @@
-libpangocairo-1.0-0
-libx11-xcb1
-libxcomposite1
-libxcursor1
-libxdamage1
-libxi6
-libxtst6
-libnss3
-libcups2
-libxss1
-libxrandr2
-libgconf2-4
-libasound2
-libatk1.0-0
-libgtk-3-0
+firefox
+chromium-browser

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,18 +1,17 @@
 channels:
-  - conda-forge
+  - conda-forge/label/jupyterlab_deck_alpha
+  - conda-forge/label/jupyterlab_fonts_alpha
   - nodefaults
 dependencies:
-  - python >=3.10,<3.11
-  - nodejs >=16,!=17.*,<19
+  - python >=3.11,<3.12
+  - nodejs >=20,<21
   # talk
   - doit
   - importnb
-  - ipydrawio
   - ipywidgets
   - jupyter-server-proxy
-  - jupyterlab >=3.6
-  - jupyterlab-deck
-  - jupyterlab-myst
+  - jupyterlab >=4.0.7
+  - jupyterlab-deck >=0.2.0a0
   # tools
   - asv
   - atheris
@@ -35,14 +34,19 @@ dependencies:
   - mypyc-ipython
   - pydocstyle
   - pyflakes
+  - pyproject-fmt
   - pytest
   - pytest-check-links
   - pytest-cov
-  - robotframework-jupyterlibrary
+  - pytest-html
+  - robotframework-jupyterlibrary >=0.5.0
+  - ruff
   - schemathesis
   - snakeviz
   - ssort
+  - taplo
   - tox
+  - vale
   # semgrep deps
   - peewee
   - boltons

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge/label/jupyterlab_deck_alpha
   - conda-forge/label/jupyterlab_fonts_alpha
+  - conda-forge
   - nodefaults
 dependencies:
   - python ==3.11.*

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge/label/jupyterlab_fonts_alpha
   - nodefaults
 dependencies:
-  - python >=3.11,<3.12
+  - python ==3.11.*
   - nodejs >=20,<21
   # talk
   - doit

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - ipywidgets
   - jupyter-server-proxy
   - jupyterlab >=4.0.7
+  - notebook >=7.0.6
   - jupyterlab-deck >=0.2.0a0
   # tools
   - asv

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
+<!-- 
+
+    This file can be viewed as a slideshow in `jupyterlab-deck`.
+
+-->
+
+---
+
 # Building Quality
 
 > _a talk about how teams can use tools to assess, maintain, and improve quality_
+
+---
 
 ## Running the talk
 
 This talk is meant to be walked through interactively.
 
+---
+
 ### On `mybinder.org` (recommended)
 
 - Launch it on [![binder-badge]][binder]
+
+---
 
 ### On Your Computer
 
@@ -29,7 +43,10 @@ This talk is meant to be walked through interactively.
     ```bash
     jupyter lab talk/00-intro.ipynb
     ```
+- open [the talk](./talk/00-intro.ipynb)
 - start JupyterLab [Deck mode][deck-mode]
+
+---
 
 ### Either Way
 
@@ -38,6 +55,8 @@ This talk is meant to be walked through interactively.
     - <kbd>space</kbd> to continue
     - <kbd>shift+enter</kbd> to run cells
         - right click on a cell output and _Enable Scrolling for Outputs_ if needed
+
+---
 
 ## Open Source
 


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/deathbeds/building-quality/deck-020-alpha)

## Changes
- [x] bump to python 3.11
- [x] bump to `jupyterlab 4` and `notebook 7` 
- [x] bump to `jupyterlab-deck 0.2.0a0`
- [ ] get `atheris` working
- [ ] get `robot` working
- [ ] get `snakeviz` (or replacement) working